### PR TITLE
Remove type constraints from policy action and resource

### DIFF
--- a/iam_policy/README.md
+++ b/iam_policy/README.md
@@ -9,7 +9,7 @@ Module to create IAM Policy in a lazy fashion
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------------- | ------- |
 | policy_description | string                                                                                                                    | Description of the policy to be created |               |         |
 | policy_name        | string                                                                                                                    | Name of the policy to be created        |               |         |
-| policy_json        | object({Version = string, Statement = list(object({Sid = string, Effect = string, Action = string, Resource = string}))}) | JSON Policy Definition                  |               |         |
+| policy_json        | object({Version = string, Statement = list(object({Sid = string, Effect = string, Action = any, Resource = any}))}) | JSON Policy Definition                  |               |         |
 | user_tags          | map(string)                                                                                                               | Mandatory User Tags                     |               |         |
 | octopus_tags       | map(string)                                                                                                               | Octopus Tags                            |               |         |
 <!-- markdownlint-enable MD013 MD033 -->

--- a/iam_policy/config.tf
+++ b/iam_policy/config.tf
@@ -1,12 +1,3 @@
 terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.27"
-    }
-  }
-
   required_version = ">= 0.14.9"
-  backend "s3" {
-  }
 }

--- a/iam_policy/variables.tf
+++ b/iam_policy/variables.tf
@@ -15,8 +15,8 @@ variable "policy_json" {
     Statement = list(object({
       Sid      = string
       Effect   = string
-      Action   = string
-      Resource = string
+      Action   = any
+      Resource = any
     }))
   })
 }

--- a/iam_role/README.md
+++ b/iam_role/README.md
@@ -11,7 +11,7 @@ Module to create IAM Role in a lazy fasion
 | description                   | string          | Description of the role to be created                                        |               |                                   |
 | trust_octopus_worker          | bool            | Add trust relationship to iaac-octopus-worker in both devops and current environment | False         |                                   |
 | managed_policies              | list(string)    | List of arns of managed policies to attach to new role                       |               |                                   |
-| inline_policies               | list(object({Name = string, policy_json = object({Version = string, Statement = list(object({Sid = string, Effect = string, Action = string, Resource = string}))})}))| List of inline policy definitions |               |                                   |
+| inline_policies               | list(object({Name = string, policy_json = object({Version = string, Statement = list(object({Sid = string, Effect = string, Action = any, Resource = any}))})}))| List of inline policy definitions |               |                                   |
 | user_tags                     | map(string)     | Mandatory User Tags                                                          |               |                                   |
 | octopus_tags                  | map(string)     | Octopus Tags                                                                 |               |                                   |
 <!-- markdownlint-enable MD013 MD033 -->

--- a/iam_role/variables.tf
+++ b/iam_role/variables.tf
@@ -39,8 +39,8 @@ variable "inline_policies" {
       Statement = list(object({
         Sid      = string
         Effect   = string
-        Action   = string
-        Resource = string
+        Action   = any
+        Resource = any
       }))
     })
   }))


### PR DESCRIPTION
# Description

Removed type constraints from action and resource in policy_json variable in iam_role and iam_policy module. Previously, these attributes had to be a string. This constraint prevented creating a policy with a list of resources or actions.

Fixes issue blocking [CLOUD-611](https://usxtech.atlassian.net/browse/CLOUD-611)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by running tfplan locally, with both a string as action and resource, and with a list of string for action and resource.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
