### PR TITLE
[ADD] Add a new secret for rds with more information

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -82,12 +82,28 @@ module "cluster" {
 ## Get Cluster details
 
 ```bash
-data "aws_db_instance" "database" {
-  db_instance_identifier = "my-test-database"
+data "aws_secretsmanager_secret" "database" {
+  name = "rds-variant-dev"
 }
 
-output "cluster" {
-  value = data.aws_db_instance.database
+data "aws_secretsmanager_secret_version" "database" {
+  secret_id = data.aws_secretsmanager_secret.database.id
+}
+
+output "host" {
+  value = jsondecode(data.aws_secretsmanager_secret_version.database.secret_string)["host"]
+}
+
+output "username" {
+  value = jsondecode(data.aws_secretsmanager_secret_version.database.secret_string)["username"]
+}
+
+output "identifier" {
+  value = jsondecode(data.aws_secretsmanager_secret_version.database.secret_string)["identifier"]
+}
+
+output "password" {
+  value = jsondecode(data.aws_secretsmanager_secret_version.database.secret_string)["password"]
 }
 ```
 

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -173,6 +173,24 @@ resource "aws_secretsmanager_secret_version" "password" {
   secret_string = module.db.db_master_password
 }
 
+resource "aws_secretsmanager_secret" "creds" {
+  name                    = "${var.identifier}-rds-creds"
+  tags                    = module.tags.tags
+  description             = local.description
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "creds" {
+  secret_id = aws_secretsmanager_secret.creds.id
+
+  secret_string = jsonencode({
+    host       = module.db.db_instance_address
+    username   = var.username
+    password   = module.db.db_master_password
+    identifier = var.identifier
+  })
+}
+
 module "replica" {
   count  = var.env == "prod" ? 1 : 0
   source = "./modules/replica"


### PR DESCRIPTION
# Description

Add a new secret for RDS so that users can use this secret to get more information about the cluster. The existing secret is still kept as such for backwards compatibility.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran Octopus Tests using the instructions provided in Contributing.md.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test
