### PR TITLE
[SUBNET] The module will return according to the name set in subnet

### DIFF
--- a/submodules/subnets/main.tf
+++ b/submodules/subnets/main.tf
@@ -1,7 +1,7 @@
 data "aws_subnet_ids" "subnets" {
   vpc_id = var.vpc_id
   filter {
-    name   = "tag:type"
-    values = [var.type]
+    name   = "tag:Name"
+    values = ["*${title(var.type)}*", "*${var.type}*"]
   }
 }


### PR DESCRIPTION
# Description

Previous module was able to get subnets only from default one. This change will allow in getting for both eksctl created VPCs and the VPCs that we create using lazy_terraform module

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in dev, prod and qa but from my local machine.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
