### PR TITLE
removed profile and region as variables

### DIFF
--- a/iam_policy/provider.tf
+++ b/iam_policy/provider.tf
@@ -1,4 +1,2 @@
 provider "aws" {
-  region  = var.region
-  profile = var.profile
 }

--- a/iam_policy/variables.tf
+++ b/iam_policy/variables.tf
@@ -1,13 +1,3 @@
-variable "profile" {
-  description = "AWS Profile"
-  default     = "default"
-}
-
-variable "region" {
-  description = "AWS Default Region"
-  default     = "us-east-1"
-}
-
 variable "policy_description" {
   description = "AWS IAM Policy Description"
   default     = ""


### PR DESCRIPTION
these aws creds and default region should be determined by octopus/root
module

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes [#8](https://usxtech.atlassian.net/browse/CLOUD-8)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test
