### PR TITLE
rabbit_mq - disable auto minor version upgrade

### DIFF
--- a/rabbit_mq/variables.tf
+++ b/rabbit_mq/variables.tf
@@ -39,7 +39,7 @@ variable "username" {
 
 variable "auto_minor_version_upgrade" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether to automatically upgrade to new minor versions of brokers as Amazon MQ makes releases available"
 }
 


### PR DESCRIPTION
# Description

A couple problems with `auto_minor_version_upgrade`
- AWS recommends we stay on 3.8.11. [Reference](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-management.html)
- When auto upgrade happens, terraform gets confused because there is an `engine_version` string also specified. See [here](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/projects/rabbitmq-environment/deployments/releases/0.1.0.97/deployments/Deployments-13167?tasklineid=0%2FServerTasks-68020_R6PDTLLD2B%2F104481a37aa34a2485f44621396e7ee5%2Fd817e776aba14de6a738bdc5a7386b5c&activeTab=taskLog)

Our dev broker was automatically updated to 3.8.17. Disabling auto upgrades here, and we will set the engine version to 3.8.17 in rabbitmq-environment as a fix.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Sanity Testing

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
