### PR TITLE
Support for AWS default_tags

### DIFF
--- a/submodules/tags/README.md
+++ b/submodules/tags/README.md
@@ -69,7 +69,7 @@ output "tags" {
 
 This will tag all AWS provider `resource`s that support tags.
 
-```
+```bash
 provider "aws" {
   default_tags {
     tags = module.tags.tags

--- a/submodules/tags/README.md
+++ b/submodules/tags/README.md
@@ -64,3 +64,15 @@ output "tags" {
   value = module.tags.tags
 }
 ```
+
+## Tagging AWS Resources
+
+This will tag all AWS provider `resource`s that support tags.
+
+```
+provider "aws" {
+  default_tags {
+    tags = module.tags.tags
+  }
+}
+```

--- a/submodules/tags/main.tf
+++ b/submodules/tags/main.tf
@@ -1,6 +1,3 @@
-# Get data for tags
-data "aws_caller_identity" "current" {}
-
 locals {
   user_tags = {
     for k, v in var.user_tags :
@@ -9,7 +6,6 @@ locals {
 
   common_tags = {
     "Name"                    = var.name
-    "aws/account_number"      = data.aws_caller_identity.current.account_id
     "octopus/project"         = var.octopus_tags.project
     "octopus/space"           = var.octopus_tags.space
     "octopus/environment"     = var.octopus_tags.environment


### PR DESCRIPTION
# Description

Currently, developers have to ensure they are tagging all AWS resources correctly by manual process of finding the `resource`s that support tags. The AWS provider has a [default_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags) argument to simplify this process in terraform projects for developers.

There is a [cyclical error](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/projects/schedule-adherence/deployments/releases/0.1.0-f-sa-000-default0001.445/deployments/Deployments-16218?tasklineid=0%2FServerTasks-84650_GPEPYE76BR%2F80a494f291724ba29b79ba714584b8c0%2F436bd43c16594b2cbf3224d8f1a62d46&activeTab=taskLog) due to the tags also using  `data "aws_caller_identity" "current" {}`
```
Error: Cycle: module.tags.data.aws_caller_identity.current, module.tags.local.common_tags (expand), module.tags.local.tags (expand), module.tags.output.tags (expand), provider["registry.terraform.io/hashicorp/aws"] 
```

This PR removes `aws/account_number` from the tags module so it can be used for `default_tags`.

Example:

```
provider "aws" {
  default_tags {
    tags = module.tags.tags
  }
}


module "tags" {
  source = "github.com/variant-inc/lazy-terraform//submodules/tags?ref=v1"

  user_tags = {
    team    = "schedule-adherence"
    purpose = "Services for calculating ETAs/break stops/driver plans"
    owner   = "schedule-adherence"
  }
  octopus_tags = var.octopus_tags

  name = "Tags"
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
