### PR TITLE
add provider

### DIFF
--- a/tf_backend_s3/provider.tf
+++ b/tf_backend_s3/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
# Description

added provider to tf_backend_s3
This is to fix issue with replicator/lazy-api creating dynamodb tables in us-west-2 instead of the provided region

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test
